### PR TITLE
Fasta Format Fix:

### DIFF
--- a/mitohelper.py
+++ b/mitohelper.py
@@ -70,7 +70,7 @@ def getrecord(input_file,output_prefix,database_file,tax_level,fasta,taxout):
 						fields=line.rsplit("\t")
 						acc=str(fields[0])
 						seq=str(fields[10])
-						fasta.write(">%s\n%s" % (acc,seq))
+						fasta.write(">%s\n%s\n" % (acc,seq))
 				
 					if taxout:
 						fields=line.rsplit("\t")


### PR DESCRIPTION
- Adding newline character at end of each sequence in FASTA output file generated by getalignment
- Following format specs from "Accepted Input Formats" section of BLAST NCBI page:
https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=BlastHelp